### PR TITLE
v16: dynamically linked python for Windows

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,2 +1,4 @@
+# Changes from v15
+  - Fix [#9](https://github.com/SynthstromAudible/dbt-toolchain/issues/9)
 # Changes from v14
   - Fix [#7](https://github.com/SynthstromAudible/dbt-toolchain/issues/7)

--- a/config.toml
+++ b/config.toml
@@ -1,4 +1,4 @@
-version = 15
+version = 16
 
 [platforms]
 [platforms.linux]
@@ -25,7 +25,7 @@ ext.default = "tar.gz"
 arch.arm64 = "aarch64"
 platform.darwin = "apple-darwin"
 platform.linux = "unknown-linux-gnu"
-platform.win32 = "pc-windows-msvc-static"
+platform.win32 = "pc-windows-msvc-shared"
 
 [packages]
 xpack.openocd = "0.12.0-1"


### PR DESCRIPTION
Fixes #9, allowing the sysex features to work on Windows.

Issue was that the statically linked python did not provide
python312.dll, which the rtmidi linked against.
